### PR TITLE
fix!: change query schemes to include 'git+' prefix

### DIFF
--- a/src/snakemake_storage_plugin_git/__init__.py
+++ b/src/snakemake_storage_plugin_git/__init__.py
@@ -208,12 +208,12 @@ class StorageProvider(StorageProviderBase):
         least one)."""
         return [
             ExampleQuery(
-                query="https://example.com/repo.git",
+                query="git+https://example.com/repo.git",
                 type=QueryType.INPUT,
                 description="The remote git repository is accessed via HTTPS.",
             ),
             ExampleQuery(
-                query="ssh://example.com/repo.git",
+                query="git+ssh://example.com/repo.git",
                 type=QueryType.INPUT,
                 description="The remote git repository is accessed via SSH.",
             ),
@@ -247,7 +247,7 @@ class StorageProvider(StorageProviderBase):
         # object is actually used.
         url_parsed = urlparse(query)
 
-        if url_parsed.scheme not in ["ssh", "https"]:
+        if url_parsed.scheme not in ["git+ssh", "git+https"]:
             return StorageQueryValidationResult(
                 query=query,
                 valid=False,


### PR DESCRIPTION
It is in general a good idea to have different storage backends distinguishable via the url scheme. Via the git+ prefix we ensure here that there are no clashes with the https storage backend.